### PR TITLE
🐛 [Fix] #42 - 부스상세 부스명 받침에 따라 맞는 조사 출력

### DIFF
--- a/src/hooks/useKoreanParticle.ts
+++ b/src/hooks/useKoreanParticle.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+
+/**
+ * 주어진 한글 문자열의 마지막 글자에 받침이 있는지 여부를 반환
+ */
+function hasFinalConsonant(word: string): boolean {
+  if (!word) return false;
+  // 마지막 글자가 특수문자(예: ) )면 그 앞 글자를 사용
+  let lastChar = word[word.length - 1];
+  if (/[^\w가-힣]/.test(lastChar) && word.length > 1) {
+    lastChar = word[word.length - 2];
+  }
+  const code = lastChar.charCodeAt(0);
+  // 한글 완성형 범위: 0xAC00 ~ 0xD7A3
+  if (code < 0xac00 || code > 0xd7a3) return false;
+  const jong = (code - 0xac00) % 28;
+  return jong !== 0;
+}
+
+/**
+ * 맞춤법에 따라 조사(을/를, 과/와)를 반환하는 훅
+ */
+export function useKoreanParticle(word: string, type: 'object' | 'with') {
+  return useMemo(() => {
+    const hasJong = hasFinalConsonant(word);
+    if (type === 'object') {
+      return hasJong ? '을' : '를';
+    }
+    if (type === 'with') {
+      return hasJong ? '과' : '와';
+    }
+    return '';
+  }, [word, type]);
+}

--- a/src/pages/boothDetail/BoothDetail.tsx
+++ b/src/pages/boothDetail/BoothDetail.tsx
@@ -7,6 +7,7 @@ import placeIcon from '@assets/icons/cardPlaceIcon.svg';
 import defaultImg from '@assets/images/boothDefaultImg.png';
 import * as S from './BoothDetail.styled';
 import { useClubBoothDetail } from '@/hooks/useClubBoothDetail';
+import { useKoreanParticle } from '@/hooks/useKoreanParticle';
 const BoothDetail = () => {
   const { id } = useParams<{ id: string }>();
   const { data: booth, isLoading, error } = useClubBoothDetail(id);
@@ -50,11 +51,15 @@ const BoothDetail = () => {
     return `${Number(month)}월 ${Number(day)}일`;
   };
 
+  const boothName = booth?.name ?? '이름없음';
+  const objectParticle = useKoreanParticle(boothName, 'object');
+  const withParticle = useKoreanParticle(boothName, 'with');
+
   if (isLoading) return <div>로딩중...</div>;
   if (error) return <div>부스 정보를 불러오지 못했습니다.</div>;
   if (!booth) return <div>부스 정보를 찾을 수 없습니다.</div>;
 
-  const currentOrder = booth.images?.[currentIndex]?.order ?? 0;
+  const currentOrder = booth?.images?.[currentIndex]?.order ?? 0;
 
   return (
     <>
@@ -123,7 +128,10 @@ const BoothDetail = () => {
             </S.InfoCardContent>
           </S.InfoCard>
           <S.InfoCard>
-            <S.CardTitleText>{booth.name}을 소개합니다</S.CardTitleText>
+            <S.CardTitleText>
+              {booth.name}
+              {objectParticle} 소개합니다
+            </S.CardTitleText>
             <S.InfoCardContent>
               <S.CardBodyText className='black'>
                 {booth.short_description}
@@ -134,7 +142,10 @@ const BoothDetail = () => {
             </S.InfoCardContent>
           </S.InfoCard>
           <S.InfoCard>
-            <S.CardTitleText>{booth.name}과 함께 해주세요!</S.CardTitleText>
+            <S.CardTitleText>
+              {booth.name}
+              {withParticle} 함께 해주세요!
+            </S.CardTitleText>
             <S.CardRecruitContents>
               <S.CardRecruitGap>
                 <S.CardBodyText className='grey500'>모집기간</S.CardBodyText>


### PR DESCRIPTION
## 📌 관련 이슈(번호)
- #42 

## ✨ 이번 PR에서 무엇을 했나요?
**간략한 작업내용**
- 부스상세에서 부스명에 따라 맞는 조사를 출력하기위해 useKoreanPractice훅을 만들어서 적용했습니당 

