### PR TITLE
[Fix] 상세 정보 있는 경우에만 자세히 보기 활성화

### DIFF
--- a/src/components/Entity/BoothCard.tsx
+++ b/src/components/Entity/BoothCard.tsx
@@ -49,13 +49,15 @@ const BoothCard = ({ booth, isActive, width = 91, height = 144, onClick, onDetai
             <img src={marker} alt='marker' />
             {booth.location}
           </BoothLocation>
-          <DetailButton onClick={(e) => {
-            e.stopPropagation();
-            onDetailClick && onDetailClick();
-          }}>
-            자세히 보기
-            <img src={arrowRight} alt='arrow-right' />
-          </DetailButton>
+          {booth.hasDetail && (
+            <DetailButton onClick={(e) => {
+              e.stopPropagation();
+              onDetailClick && onDetailClick();
+            }}>
+              자세히 보기
+              <img src={arrowRight} alt='arrow-right' />
+            </DetailButton>
+          )}
         </BoothInfo>
       </ContentContainer>
     </BoothCardWrapper>

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -49,7 +49,7 @@ export const useQuiz = () => {
                     "/api/quiz/submit",
                     { division_ids: updatedDivisionIds }
                 );
-                //console.log(result);
+                console.log(result);
                 navigate("/test/result", { state: { result } });
             } catch (err) {
                 console.warn("Failed to submit quiz, using mock result:", err);

--- a/src/mocks/mockQuiz.ts
+++ b/src/mocks/mockQuiz.ts
@@ -84,7 +84,8 @@ export const mockQuizResult: QuizResultResponse = {
             dates: ["2026-03-04", "2026-03-05"],
             location_name: "만해광장",
             loc_num: 100,
-            logo_url: defaultImg
+            logo_url: defaultImg,
+            has_detail: false
             },
         
         {
@@ -95,7 +96,8 @@ export const mockQuizResult: QuizResultResponse = {
             dates: ["2026-03-04", "2026-03-05"],
             loc_num: 1,
             location_name: "학생회관 앞 광장",
-            logo_url: "https://cf-tabs-image.campuspick.com/clubrecruit/1686551931804562.jpg"
+            logo_url: "https://cf-tabs-image.campuspick.com/clubrecruit/1686551931804562.jpg",
+            has_detail: true
         },
         {
             booth_id: 3,
@@ -105,7 +107,8 @@ export const mockQuizResult: QuizResultResponse = {
             dates: ["2026-03-05"],
             loc_num: 51,
             location_name: "대강당 앞",
-            logo_url: "https://images.unsplash.com/photo-1501386761578-eac5c94b800a?q=80&w=1000&auto=format&fit=crop"
+            logo_url: "https://images.unsplash.com/photo-1501386761578-eac5c94b800a?q=80&w=1000&auto=format&fit=crop",
+            has_detail: true
         }
     ]
 };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7,4 +7,5 @@ export interface BoothAPIResult {
     location_name: string;
     loc_num: number;
     logo_url: string;
+    has_detail: boolean;
 }

--- a/src/types/booth.ts
+++ b/src/types/booth.ts
@@ -49,6 +49,7 @@ export interface BoothCardData {
   locNum: number;
   location: string;
   image: string;
+  hasDetail: boolean;
 }
 
 export interface BoothQueryParams {

--- a/src/utils/boothUtils.ts
+++ b/src/utils/boothUtils.ts
@@ -32,4 +32,5 @@ export const mapBoothResultToBoothCardData = (result: BoothAPIResult): BoothCard
     locNum: result.loc_num,
     location: `${result.location_name} ${result.loc_num}번`,
     image: result.logo_url,
+    hasDetail: result.has_detail,
 });


### PR DESCRIPTION
## 📌 관련 이슈(번호)
- close #44 

## ✨ 이번 PR에서 무엇을 했나요?
**간략한 작업내용**
- 부스 상세 정보가 있는 경우에만 자세히 보기 버튼이 활성화됩니다.

## 📸 스크린샷 (선택)
**UI 변경사항이 있다면 첨부**

## 📚 참고 사항
- 
